### PR TITLE
Add options to not delete test or provided dependencies

### DIFF
--- a/src/main/java/com/github/gemba/artifactresolver/DependencyResolver.java
+++ b/src/main/java/com/github/gemba/artifactresolver/DependencyResolver.java
@@ -60,7 +60,7 @@ public class DependencyResolver {
    * @throws DependencyResolutionException
    *           if a dependency is not resolvable
    */
-  public void downloadDependencyTree(DefaultArtifact artifact, boolean javadoc, boolean sources)
+  public void downloadDependencyTree(DefaultArtifact artifact, boolean javadoc, boolean sources, boolean withoutTests)
       throws DependencyCollectionException, DependencyResolutionException {
     log.info("Resolving: {} with these dependencies ...", artifact.toString());
 
@@ -68,8 +68,11 @@ public class DependencyResolver {
 
     DependencyNode jarNode = repoSystemHelper.collectDependencies(dependency);
 
-    DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.TEST);
-    jarNode.accept(new TreeDependencyVisitor(new FilteringDependencyVisitor(new DependencyGraphPrinter(), classpathFilter)));
+    DependencyFilter classpathFilter = null;
+    if (!withoutTests) {
+    	classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.TEST);
+    	jarNode.accept(new TreeDependencyVisitor(new FilteringDependencyVisitor(new DependencyGraphPrinter(), classpathFilter)));
+    }
 
     DependencyRequest dependencyRequest = new DependencyRequest(jarNode, classpathFilter);
     DependencyResult dependencyResult = repoSystemHelper.resolveDependencies(dependencyRequest);

--- a/src/main/java/com/github/gemba/artifactresolver/DependencyResolver.java
+++ b/src/main/java/com/github/gemba/artifactresolver/DependencyResolver.java
@@ -72,6 +72,8 @@ public class DependencyResolver {
     if (!withoutTests) {
     	classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.TEST);
     	jarNode.accept(new TreeDependencyVisitor(new FilteringDependencyVisitor(new DependencyGraphPrinter(), classpathFilter)));
+    } else {
+    	jarNode.accept(new DependencyGraphPrinter());
     }
 
     DependencyRequest dependencyRequest = new DependencyRequest(jarNode, classpathFilter);

--- a/src/main/java/com/github/gemba/artifactresolver/MavenDependencyDownloader.java
+++ b/src/main/java/com/github/gemba/artifactresolver/MavenDependencyDownloader.java
@@ -49,6 +49,7 @@ public class MavenDependencyDownloader {
   private static boolean javadoc = false;
   private static boolean sources = false;
   private static boolean withoutTests = false;
+  private static boolean withoutProvided = false;
   private static String dependencyFile;
   private static String localRepo;
   private static ArrayList<DefaultArtifact> artifacts;
@@ -70,7 +71,7 @@ public class MavenDependencyDownloader {
 
     readExtraRepos();
 
-    RepositorySystemHelper repoSystemHelper = new RepositorySystemHelper(localRepo, extraRepos);
+    RepositorySystemHelper repoSystemHelper = new RepositorySystemHelper(localRepo, extraRepos, withoutProvided);
     dependencyResolver = new DependencyResolver(repoSystemHelper);
 
     if (artifacts.isEmpty()) {
@@ -126,7 +127,11 @@ public class MavenDependencyDownloader {
     }
     
     if (line.hasOption('t')) {
-        withoutTests = true;
+      withoutTests = true;
+    }
+    
+    if (line.hasOption('p')) {
+      withoutProvided = true;
     }
 
     dependencyFile = line.getOptionValue('f', DEFAULT_DEPENDENCY_FILE);
@@ -161,6 +166,7 @@ public class MavenDependencyDownloader {
     Option javadoc = Option.builder("j").longOpt("with-javadoc").desc("download javadoc attachment of artifact").build();
     Option sources = Option.builder("s").longOpt("with-sources").desc("download source attachment of artifact").build();
     Option withoutTests = Option.builder("t").longOpt("without-tests").desc("don't download test dependencies of artifact").build();
+    Option withoutProvided = Option.builder("p").longOpt("without-provided").desc("don't download provided dependencies of artifact").build();
 
     options.addOption(help);
     options.addOption(depDir);
@@ -168,6 +174,7 @@ public class MavenDependencyDownloader {
     options.addOption(javadoc);
     options.addOption(sources);
     options.addOption(withoutTests);
+    options.addOption(withoutProvided);
   }
 
   /**

--- a/src/main/java/com/github/gemba/artifactresolver/MavenDependencyDownloader.java
+++ b/src/main/java/com/github/gemba/artifactresolver/MavenDependencyDownloader.java
@@ -48,6 +48,7 @@ public class MavenDependencyDownloader {
 
   private static boolean javadoc = false;
   private static boolean sources = false;
+  private static boolean withoutTests = false;
   private static String dependencyFile;
   private static String localRepo;
   private static ArrayList<DefaultArtifact> artifacts;
@@ -87,11 +88,11 @@ public class MavenDependencyDownloader {
         String version = (String) jsonObj.get("version");
 
         DefaultArtifact artifact = new DefaultArtifact(groupId, artifactId, classifier, extension, version);
-        dependencyResolver.downloadDependencyTree(artifact, javadoc, sources);
+        dependencyResolver.downloadDependencyTree(artifact, javadoc, sources, withoutTests);
       }
     } else {
       for (DefaultArtifact artifact : artifacts) {
-        dependencyResolver.downloadDependencyTree(artifact, javadoc, sources);
+        dependencyResolver.downloadDependencyTree(artifact, javadoc, sources, withoutTests);
       }
     }
     log.info("... artifacts downloaded to \"{}\". Finished. Thank you.", localRepo);
@@ -122,6 +123,10 @@ public class MavenDependencyDownloader {
 
     if (line.hasOption('s')) {
       sources = true;
+    }
+    
+    if (line.hasOption('t')) {
+        withoutTests = true;
     }
 
     dependencyFile = line.getOptionValue('f', DEFAULT_DEPENDENCY_FILE);
@@ -155,12 +160,14 @@ public class MavenDependencyDownloader {
 
     Option javadoc = Option.builder("j").longOpt("with-javadoc").desc("download javadoc attachment of artifact").build();
     Option sources = Option.builder("s").longOpt("with-sources").desc("download source attachment of artifact").build();
+    Option withoutTests = Option.builder("t").longOpt("without-tests").desc("don't download test dependencies of artifact").build();
 
     options.addOption(help);
     options.addOption(depDir);
     options.addOption(jsonFile);
     options.addOption(javadoc);
     options.addOption(sources);
+    options.addOption(withoutTests);
   }
 
   /**

--- a/src/main/java/com/github/gemba/artifactresolver/RepositorySystemHelper.java
+++ b/src/main/java/com/github/gemba/artifactresolver/RepositorySystemHelper.java
@@ -63,10 +63,10 @@ public class RepositorySystemHelper {
    * @param extraRepos
    *          map with extra repositories <id, url>.
    */
-  public RepositorySystemHelper(String localRepoDir, Map<String, String> extraRepos) {
+  public RepositorySystemHelper(String localRepoDir, Map<String, String> extraRepos, boolean withoutProvided) {
     repoSystem = newRepositorySystem();
 
-    session = newSession(repoSystem, localRepoDir);
+    session = newSession(repoSystem, localRepoDir, withoutProvided);
 
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build();
 
@@ -118,20 +118,22 @@ public class RepositorySystemHelper {
    *          the directory where to put the downloaded artifacts
    * @return the configured repository session
    */
-  private RepositorySystemSession newSession(RepositorySystem system, final String localDownloadDir) {
+  private RepositorySystemSession newSession(RepositorySystem system, final String localDownloadDir, boolean withoutProvided) {
     DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
 
     LocalRepository localRepo = new LocalRepository(localDownloadDir);
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
 
-    DependencySelector depFilter =
-        new AndDependencySelector(
-        new ScopeDependencySelector(JavaScopes.PROVIDED),
-        new OptionalDependencySelector(),
-        new ExclusionDependencySelector()
-    );
-    session.setDependencySelector(depFilter);
-
+    if (!withoutProvided) {
+	    DependencySelector depFilter =
+	        new AndDependencySelector(
+	        new ScopeDependencySelector(JavaScopes.PROVIDED),
+	        new OptionalDependencySelector(),
+	        new ExclusionDependencySelector()
+	    );
+	    session.setDependencySelector(depFilter);
+    }
+    
     return session;
   }
 


### PR DESCRIPTION
Sometimes test or provided tests might not be on the central repository.
Also you don't always need test dependencies if you're using the artifact for production only.
